### PR TITLE
Fix auth issue

### DIFF
--- a/src/components/UserSearchPage.tsx
+++ b/src/components/UserSearchPage.tsx
@@ -4,15 +4,14 @@ import ApolloClient from "apollo-boost";
 import UserSearch from "./UserSearch";
 import * as React from "react";
 
-const gitHubToken = auth.getAccessToken();
-const apolloClient = new ApolloClient({
-  uri: "https://api.github.com/graphql",
-  headers: {
-    authorization: `Bearer ${gitHubToken}`
-  }
-});
-
 const UserSearchPage = () => {
+  const gitHubToken = auth.getAccessToken();
+  const apolloClient = new ApolloClient({
+    uri: "https://api.github.com/graphql",
+    headers: {
+      authorization: `Bearer ${gitHubToken}`
+    }
+  });
   if (apolloClient !== null) {
     return (
       <ApolloProvider client={apolloClient}>


### PR DESCRIPTION
Since the github token is not set in the render, search doesn't work after initial login and we've to refresh the page for it to work. This change fixes it.

Closes #2 